### PR TITLE
Remove write to /dev/urandom functionality

### DIFF
--- a/randomsanity
+++ b/randomsanity
@@ -56,15 +56,6 @@ checkbytes() {
                 ;;
         esac
 
-        # RESPONSE contains entropy from the server (X-Entropy); mix it in to /dev/urandom:
-        local resp
-        for resp in "${RESPONSE[@]}"; do
-            if [[ "$(cut -d':' -f1 <<< "$resp")" == "X-Entropy" ]]; then
-                printf "%s" "$resp" | cut -d' ' -f2 | tr -d '\n\r' >> /dev/urandom
-                break
-            fi
-        done
-
         return 0
 }
 


### PR DESCRIPTION
Due to security concerns, and given that it was out of the script's scope, we
decided to remove this functionality alltogether[1].

[1] https://github.com/RandomSanityProject/randomsanity_debian/pull/5#issuecomment-299007938